### PR TITLE
USB fixed

### DIFF
--- a/source_code/aux_mcu/src/COMM/comm.c
+++ b/source_code/aux_mcu/src/COMM/comm.c
@@ -11,11 +11,13 @@
 #include <string.h>
 #ifdef BOOTLOADER
     #include "bootloader.h"
+#else
+    #include "usbhid.h"
 #endif
 
 /* buffer for RX/TX DMA USART */
-T_comm_msg comm_rx __attribute__ ((aligned (4)));
-T_comm_msg comm_tx __attribute__ ((aligned (4)));
+T_comm_rx_msg comm_rx __attribute__ ((aligned (4)));
+T_comm_tx_msg comm_tx __attribute__ ((aligned (4)));
 
 /* counter of the number of bytes transfered through DMA */
 uint16_t comm_tx_dma_index;
@@ -51,11 +53,8 @@ void comm_init(void){
 void comm_task(void){
     /* Check if for USART RX reception through DMA */
     if(dma_aux_mcu_check_and_clear_dma_transfer_flag()){
-        /* Send message to USB if payload is valid */
-        if(comm_rx.payload_valid){
-            /* Process message and send it to destination */
-            comm_process_out_msg((T_comm_msg_type)comm_rx.msg_type, comm_rx.payload, comm_rx.payload_len );
-        }
+        /* Process message and send it to destination */
+        comm_process_out_msg((T_comm_msg_type)comm_rx.msg_type, comm_rx.payload, comm_rx.payload_len2);
         /* Reconfigure RX DMA, comm_rx is free at this point */
         dma_aux_mcu_init_rx_transfer(&comm_rx, sizeof(comm_rx));
     }
@@ -82,14 +81,13 @@ void comm_process_out_msg(T_comm_msg_type msg_type, uint8_t* buff, uint16_t buff
 #else
         case COMM_MSG_TO_BOOTLOADER:
             if(bootloader_process_msg(buff, buff_len) == true){
-                memcpy(&comm_tx, &comm_rx, sizeof(T_comm_msg));
+                memcpy(&comm_tx, &comm_rx, sizeof(T_comm_tx_msg));
                 dma_aux_mcu_init_tx_transfer( &comm_tx, sizeof(comm_rx));
             } else{
-                memcpy(&comm_tx, &comm_rx, sizeof(T_comm_msg));
+                memcpy(&comm_tx, &comm_rx, sizeof(T_comm_tx_msg));
                 memset(comm_tx.payload, 0xFF, COMM_PAYLOAD_SIZE);
                 dma_aux_mcu_init_tx_transfer( &comm_tx, sizeof(comm_rx));
             }
-            //while(!dma_aux_mcu_check_and_clear_tx_transfer_flag());
             break;
 #endif
         default:
@@ -118,20 +116,20 @@ void comm_usb_process_in_pkt(T_comm_pkt_status pkt_status, uint8_t* data, uint16
     if( pkt_status.msg_start ){
         /* Reset vars */
         comm_tx_dma_index = 0u;
-        comm_tx.payload_len = 0u;
+        comm_tx.payload_len2 = 0u;
         /* Write Header */
         comm_tx.msg_type = COMM_MSG_FROM_USB;
-        comm_tx.reserved = 0u;
+        comm_tx.payload_len1 = 0u;
         /* Increment the number bytes to be sent */
         dma_bytes += sizeof(comm_tx.msg_type);
-        dma_bytes += sizeof(comm_tx.reserved);
+        dma_bytes += sizeof(comm_tx.payload_len1);
     }
 
     /* Payload */
-    if( (comm_tx.payload_len+data_len) <= COMM_PAYLOAD_SIZE ){
+    if( (comm_tx.payload_len2+data_len) <= COMM_PAYLOAD_SIZE ){
         /* copy data into comm_tx payload */
-        memcpy(&comm_tx.payload[comm_tx.payload_len], data, data_len );
-        comm_tx.payload_len += data_len;
+        memcpy(&comm_tx.payload[comm_tx.payload_len2], data, data_len );
+        comm_tx.payload_len2 += data_len;
     } else{
         err = true;
     }
@@ -139,9 +137,14 @@ void comm_usb_process_in_pkt(T_comm_pkt_status pkt_status, uint8_t* data, uint16
     /* Actions to do if end of pkt */
     if( pkt_status.msg_end ){
         /* Increment the bytes to be sent */
-        dma_bytes += (COMM_PAYLOAD_SIZE - comm_tx.payload_len);
-        dma_bytes += sizeof(comm_tx.payload_len);
+        dma_bytes += (COMM_PAYLOAD_SIZE - comm_tx.payload_len2);
+        dma_bytes += sizeof(comm_tx.payload_len2);
         dma_bytes += sizeof(comm_tx.payload_valid);
+        /* */
+        if(data_len == comm_tx.payload_len2){
+            comm_tx.payload_len1 = comm_tx.payload_len2;
+        }
+
         /* valid message */
         comm_tx.payload_valid = COMM_PAYLOAD_VALID;
     }

--- a/source_code/aux_mcu/src/COMM/comm.h
+++ b/source_code/aux_mcu/src/COMM/comm.h
@@ -15,14 +15,23 @@
 #define COMM_PAYLOAD_VALID      (true)
 #define COMM_PAYLOAD_NOT_VALID  (false)
 
-/* Message type */
+/* Message Structure main mcu to aux mcu */
 typedef struct {
     uint16_t msg_type;
-    uint16_t reserved;
-    uint8_t  payload[COMM_PAYLOAD_SIZE];
     uint16_t payload_len;
+    uint8_t  payload[COMM_PAYLOAD_SIZE];
+    uint16_t payload_len2;
+    uint16_t reply;
+} T_comm_rx_msg;
+
+/* Message Structure aux mcu to main mcu */
+typedef struct {
+    uint16_t msg_type;
+    uint16_t payload_len1;
+    uint8_t  payload[COMM_PAYLOAD_SIZE];
+    uint16_t payload_len2;
     uint16_t payload_valid;
-} T_comm_msg;
+} T_comm_tx_msg;
 
 /* Message Type enum */
 typedef enum comm_msg_type{

--- a/source_code/aux_mcu/src/USBHID/usbhid.c
+++ b/source_code/aux_mcu/src/USBHID/usbhid.c
@@ -47,7 +47,6 @@ typedef struct{
     uint8_t* data;
 } T_usbhid_msg;
 
-
 /** Private data Declaration -----------------------------------------------  */
 
 /** Message Buffer allocation */
@@ -58,6 +57,10 @@ static bool rx_msg_flip;
 static uint8_t rx_pkt_counter;
 /** Total message length */
 static uint16_t rx_msg_size;
+/** USB data copied in USB interrupt callback */
+static T_usbhid_pkt usb_data;
+/** Flag to mark new data from USB */
+static bool usb_isr_received;
 
 /**
  * \fn      usbhid_init
@@ -67,6 +70,64 @@ void usbhid_init(void){
     rx_msg_flip = false;
     rx_pkt_counter = 0u;
     rx_msg_size = 0u;
+    usb_isr_received = false;
+}
+
+/**
+ * \fn      usbhid_task
+ * \brief   cyclic task to process USB data
+ */
+void usbhid_task(void){
+    if(usb_isr_received){
+        T_usbhid_pkt *pkt = &usb_data;
+        T_comm_pkt_status pkt_status;
+        bool err = false;
+
+        /* Check new message flip bit  */
+        if(USBHID_new_msg_received(pkt->control.msg_flip)){
+            rx_msg_size = 0u;
+            rx_pkt_counter = 0u;
+            rx_msg_flip = pkt->control.msg_flip;
+        }
+
+        /* Analyze packet counter */
+        if(USBHID_check_pkt_counter(pkt->control.pkt_id)){
+            err = true;
+        }
+
+        /* Process incoming packet if no error has been detected */
+        if( !err ){
+            /* Copy from incoming pkt to buffer ( */
+            memcpy(&usbhid_rx_buffer[rx_msg_size], pkt->payload, pkt->control.len );
+            rx_msg_size+= pkt->control.len;
+            rx_pkt_counter++;
+
+            /* Pkt status */
+            pkt_status.msg_start = (pkt->control.pkt_id == 0);
+            pkt_status.msg_end = (pkt->control.pkt_id == pkt->control.total_pkts);
+
+            /* Send pkt to MAIN MCU by means of USART */
+            comm_usb_process_in_pkt(pkt_status, pkt->payload, pkt->control.len);
+
+            /* Check if the end of packet has arrived */
+            if(pkt_status.msg_end){
+                /* Answer to Host */
+                if(pkt->control.final_ack){
+                    udi_hid_generic_send_report_in((uint8_t*)pkt, pkt->control.len+USBHID_PKT_HEADER_SIZE);
+                }
+                /* Reset Counters */
+                rx_msg_size = 0u;
+                rx_pkt_counter = 0u;
+            }
+        } else{
+            /* Protocol Error detected, reinitialize counters */
+            rx_msg_size = 0u;
+            rx_pkt_counter = 0u;
+            /* Send Error message ? */
+        }
+
+        usb_isr_received = false;
+    }
 }
 
 /**
@@ -78,53 +139,8 @@ void usbhid_init(void){
  * \param data  Pointer to raw hid packet received from USB
  */
 void usbhid_usb_callback(uint8_t *data){
-    T_usbhid_pkt *pkt = (T_usbhid_pkt*)data;
-    T_comm_pkt_status pkt_status;
-    bool err = false;
-
-    /* Check new message flip bit  */
-    if(USBHID_new_msg_received(pkt->control.msg_flip)){
-        rx_msg_size = 0u;
-        rx_pkt_counter = 0u;
-        rx_msg_flip = pkt->control.msg_flip;
-    }
-
-    /* Analyze packet counter */
-    if(USBHID_check_pkt_counter(pkt->control.pkt_id)){
-        err = true;
-    }
-
-    /* Process incoming packet if no error has been detected */
-    if( !err ){
-        /* Copy from incoming pkt to buffer */
-        memcpy(&usbhid_rx_buffer[rx_msg_size], pkt->payload, pkt->control.len );
-        rx_msg_size+= pkt->control.len;
-        rx_pkt_counter++;
-
-        /* Pkt status */
-        pkt_status.msg_start = (pkt->control.pkt_id == 0);
-        pkt_status.msg_end = (pkt->control.pkt_id == pkt->control.total_pkts);
-
-        /* Send pkt to MAIN MCU by means of USART */
-        comm_usb_process_in_pkt(pkt_status,pkt->payload, pkt->control.len);
-
-        /* Check if the end of packet has arrived */
-        if(pkt_status.msg_end){
-            /* Answer to Host */
-            if(pkt->control.final_ack){
-                udi_hid_generic_send_report_in(data, pkt->control.len+USBHID_PKT_HEADER_SIZE);
-            }
-            /* Reset Counters */
-            rx_msg_size = 0u;
-            rx_pkt_counter = 0u;
-        }
-    } else{
-        /* Protocol Error detected, reinitialize counters */
-        rx_msg_size = 0u;
-        rx_pkt_counter = 0u;
-        /* Send Error message ? */
-    }
-
+        memcpy(&usb_data, data, sizeof(usb_data));
+        usb_isr_received = true;
 }
 
 /**
@@ -136,25 +152,21 @@ void usbhid_usb_callback(uint8_t *data){
  * \param buff_len  Data length
  */
 void usbhid_send_to_usb(uint8_t* buff, uint16_t buff_len){
-    uint16_t pkt_number;
-    uint8_t pkt_id;
     T_usbhid_pkt pkt;
     uint16_t buff_idx = 0;
 
     /* Compute packet fragmentation */
-    pkt_number = buff_len / USBHID_MAX_MSG_SIZE;
+    pkt.control.total_pkts = buff_len / USBHID_MAX_PAYLOAD;
 
-    if( ((buff_len%USBHID_MAX_MSG_SIZE) == 0) &&
-        (buff_len != 0) ){
-        pkt_number--;
+    if( ((buff_len%USBHID_MAX_PAYLOAD) == 0) &&
+        (buff_len > 0) ){
+        pkt.control.total_pkts--;
     }
 
-    for(pkt_id = 0; pkt_id <= pkt_number; pkt_id++){
+    for(pkt.control.pkt_id = 0; pkt.control.pkt_id <= pkt.control.total_pkts; pkt.control.pkt_id++){
         /* Compute Header */
         pkt.control.len = ((uint16_t)(buff_len - buff_idx) >= USBHID_MAX_PAYLOAD) ? (USBHID_MAX_PAYLOAD) : (uint8_t)(buff_len - buff_idx);
         pkt.control.msg_flip = rx_msg_flip;
-        pkt.control.pkt_id = pkt_id;
-        pkt.control.total_pkts = pkt_number;
         pkt.control.final_ack = false;
 
         /* copy data to pkt.payload */

--- a/source_code/aux_mcu/src/USBHID/usbhid.h
+++ b/source_code/aux_mcu/src/USBHID/usbhid.h
@@ -17,6 +17,7 @@
 #define USBHID_PKT_HEADER_SIZE  (2U)
 
 void usbhid_init(void);
+void usbhid_task(void);
 void usbhid_usb_callback(uint8_t *data);
 void usbhid_send_to_usb(uint8_t* buff, uint16_t buff_len);
 

--- a/source_code/aux_mcu/src/main.c
+++ b/source_code/aux_mcu/src/main.c
@@ -137,6 +137,9 @@ int main(void) {
     // because the USB management is done by interrupt
     while (true) {
         //sleepmgr_enter_sleep();
+        /* USB task */
+        usbhid_task();
+        /* USART task */
         comm_task();
     }
 #else


### PR DESCRIPTION
Avoid sending USB messages inside USB interrupt.
Moved USB processing from interrupt to task.
Fixed: aux_mcu not able to send messages greater than 54
Removed payload valid check from main_mcu messages.