### PR TITLE
Add missing include of stdlib.h to src/EMU/lis2hh12.c

### DIFF
--- a/source_code/main_mcu/src/EMU/lis2hh12.c
+++ b/source_code/main_mcu/src/EMU/lis2hh12.c
@@ -1,4 +1,5 @@
 #include "lis2hh12.h"
+#include <stdlib.h>
 #include <unistd.h>
 #include <fcntl.h>
 #include <time.h>


### PR DESCRIPTION
The make failed on debian because gcc threw the following errors:
src/EMU/lis2hh12.c:14:76: error: implicit declaration of function ‘rand’; did you mean ‘read’? [-Werror=implicit-function-declaration]
src/EMU/lis2hh12.c:21:91: error: implicit declaration of function ‘srand’; did you mean ‘scanf’? [-Werror=implicit-function-declaration]

Including stdlib.h fixed the errors.
