### PR TITLE
Add setting DESTDIR and PREFIX to Qt's minible_emu.pro

### DIFF
--- a/source_code/main_mcu/minible_emu.pro
+++ b/source_code/main_mcu/minible_emu.pro
@@ -144,6 +144,8 @@ QMAKE_CXXFLAGS += -fdata-sections \
     -fPIC
     
 DEFINES += EMULATOR_BUILD
+DEFINES += DESTDIR=""
+DEFINES += PREFIX="/usr"
 
 HEADERS  += src/MainWindow.h \ \
     src/BearSSL/inc/bearssl.h \


### PR DESCRIPTION
Makefile.emu was modified to pass its DESTDIR and PREFIX variables to
the compiler, but the same thing needs to be done to minible_emu.pro.
This change does that.  It appears that steps could be added in the
build process to do an install in qtcreator, but that seemed like an
enhancement that might not be used.  This change simply brings Qt's
qmake on par with make.