### PR TITLE
Fix for issue #76 (two prompts when logging in)

### DIFF
--- a/source_code/aux_mcu/src/COMMS/comms_main_mcu.h
+++ b/source_code/aux_mcu/src/COMMS/comms_main_mcu.h
@@ -100,6 +100,11 @@ extern volatile BOOL comms_main_mcu_other_msg_answered_using_first_bytes;
 #define AUX_MCU_MSG_TYPE_FIDO2_END   AUX_MCU_FIDO2_RETRY
 /* FIDO2 messages end */
 
+/*
+ * Flags for Get Assertion request to Main MCU
+ */
+#define FIDO2_GA_FLAG_SILENT        0x1 // Indicates to not prompt for user ACK
+
 /* Typedefs */
 typedef struct
 {
@@ -248,6 +253,7 @@ typedef struct fido2_get_assertion_req_message_s
     uint8_t rpID[FIDO2_RPID_LEN];
     uint8_t client_data_hash[FIDO2_CLIENT_DATA_HASH_LEN];
     fido2_allow_list_t allow_list;
+    uint8_t flags;
 } fido2_get_assertion_req_message_t;
 
 typedef struct fido2_get_assertion_rsp_message_s

--- a/source_code/aux_mcu/src/fido2/ctap.c
+++ b/source_code/aux_mcu/src/fido2/ctap.c
@@ -273,6 +273,7 @@ static ret_type_te ctap_get_assertion_aux_comm(CTAP_requestCommon *common, CTAP_
     fido2_get_assertion_req_message_t *req_msg;
     ret_type_te ret = RETURN_NOK;
     uint8_t i;
+    uint8_t uv_up = 0;
 
     /* Create message to make authentication data */
     comms_main_mcu_get_empty_packet_ready_to_be_sent(&temp_tx_message_pt, AUX_MCU_MSG_TYPE_FIDO2);
@@ -294,6 +295,15 @@ static ret_type_te ctap_get_assertion_aux_comm(CTAP_requestCommon *common, CTAP_
     {
         memcpy(&req_msg->allow_list.tag[i], GA->creds[i].id.tag, sizeof(req_msg->allow_list.tag[i]));
     }
+
+    /*
+     * Determine whether we should prompt the user or not
+     * Prompt under the following conditions:
+     * 1. Either UV or UP or both is 1
+     * 2. UP missing (case currently for demo.yubico.com/webauthn)
+     */
+    uv_up = GA->uv + GA->up;
+    req_msg->flags = (!uv_up && GA->upPresent == 1) ? FIDO2_GA_FLAG_SILENT : 0;
 
     memcpy(req_msg->client_data_hash, common->clientDataHash, FIDO2_CLIENT_DATA_HASH_LEN);
 

--- a/source_code/aux_mcu/src/fido2/ctap.h
+++ b/source_code/aux_mcu/src/fido2/ctap.h
@@ -244,6 +244,8 @@ typedef struct
 
     uint8_t uv;
     uint8_t up;
+    uint8_t uvPresent;
+    uint8_t upPresent;
 } CTAP_makeCredential;
 
 typedef struct
@@ -259,6 +261,8 @@ typedef struct
 
     CTAP_credentialDescriptor creds[ALLOW_LIST_MAX_SIZE];
     uint8_t allowListPresent;
+    uint8_t upPresent;
+    uint8_t uvPresent;
 } CTAP_getAssertion;
 
 void ctap_response_init(CTAP_RESPONSE * resp);

--- a/source_code/aux_mcu/src/fido2/ctap_parse.c
+++ b/source_code/aux_mcu/src/fido2/ctap_parse.c
@@ -463,7 +463,7 @@ uint8_t parse_rp(struct rpId * rp, CborValue * val)
     return 0;
 }
 
-uint8_t parse_options(CborValue * val, uint8_t * rk, uint8_t * uv, uint8_t * up)
+uint8_t parse_options(CborValue * val, uint8_t * rk, uint8_t * uv, uint8_t *uvPresent, uint8_t * up, uint8_t *upPresent)
 {
     size_t sz, map_length;
     char key[8];
@@ -471,6 +471,11 @@ uint8_t parse_options(CborValue * val, uint8_t * rk, uint8_t * uv, uint8_t * up)
     unsigned int i;
     _Bool b;
     CborValue map;
+
+    *up = 0;
+    *uv = 0;
+    *upPresent = 0;
+    *uvPresent = 0;
 
     if (cbor_value_get_type(val) != CborMapType)
     {
@@ -525,6 +530,7 @@ uint8_t parse_options(CborValue * val, uint8_t * rk, uint8_t * uv, uint8_t * up)
             check_ret(ret);
             printf1(TAG_GA, "uv: %d\r",b);
             *uv = b;
+            *uvPresent = 1;
         }
         else if (strncmp(key, "up",2) == 0)
         {
@@ -532,6 +538,7 @@ uint8_t parse_options(CborValue * val, uint8_t * rk, uint8_t * uv, uint8_t * up)
             check_ret(ret);
             printf1(TAG_GA, "up: %d\r",b);
             *up = b;
+            *upPresent = 1;
         }
         else
         {
@@ -657,7 +664,7 @@ uint8_t ctap_parse_make_credential(CTAP_makeCredential * MC, CborEncoder * encod
 
             case MC_options:
                 printf1(TAG_MC,"CTAP_options");
-                ret = parse_options(&map, &MC->credInfo.rk, &MC->uv, &MC->up);
+                ret = parse_options(&map, &MC->credInfo.rk, &MC->uv, &MC->uvPresent, &MC->up, &MC->upPresent);
                 check_retr(ret);
                 break;
             case MC_pinAuth: {
@@ -883,7 +890,7 @@ uint8_t ctap_parse_get_assertion(CTAP_getAssertion * GA, uint8_t * request, int 
 
             case GA_options:
                 printf1(TAG_GA,"CTAP_options");
-                ret = parse_options(&map, &GA->rk, &GA->uv, &GA->up);
+                ret = parse_options(&map, &GA->rk, &GA->uv, &GA->uvPresent, &GA->up, &GA->upPresent);
                 check_retr(ret);
                 break;
             case GA_pinAuth: {

--- a/source_code/aux_mcu/src/fido2/ctap_parse.h
+++ b/source_code/aux_mcu/src/fido2/ctap_parse.h
@@ -27,7 +27,7 @@ uint8_t parse_pub_key_cred_params(CTAP_makeCredential * MC, CborValue * val);
 uint8_t parse_fixed_byte_string(CborValue * map, uint8_t * dst, unsigned int len);
 uint8_t parse_rp_id(struct rpId * rp, CborValue * val);
 uint8_t parse_rp(struct rpId * rp, CborValue * val);
-uint8_t parse_options(CborValue * val, uint8_t * rk, uint8_t * uv, uint8_t * up);
+uint8_t parse_options(CborValue * val, uint8_t * rk, uint8_t * uv, uint8_t *uvPresent, uint8_t * up, uint8_t *upPresent);
 
 uint8_t parse_allow_list(CTAP_getAssertion * GA, CborValue * it);
 uint8_t parse_cose_key(CborValue * it, COSE_key * cose);

--- a/source_code/main_mcu/src/COMMS/comms_aux_mcu_defines.h
+++ b/source_code/main_mcu/src/COMMS/comms_aux_mcu_defines.h
@@ -109,6 +109,13 @@
 #define AUX_MCU_MSG_TYPE_FIDO2_END          AUX_MCU_FIDO2_RETRY
 /* FIDO2 messages end */
 
+/*
+ * Flags for Get Assertion request to Main MCU
+ */
+
+// Indicates to not prompt for user ACK
+#define FIDO2_GA_FLAG_SILENT        0x1
+
 /* Typedefs */
 typedef struct
 {
@@ -256,6 +263,7 @@ typedef struct fido2_get_assertion_req_message_s
     uint8_t rpID[FIDO2_RPID_LEN];
     uint8_t client_data_hash[FIDO2_CLIENT_DATA_HASH_LEN];
     fido2_allow_list_t allow_list;
+    uint8_t flags;
 } fido2_get_assertion_req_message_t;
 
 typedef struct fido2_get_assertion_rsp_message_s

--- a/source_code/main_mcu/src/LOGIC/logic_fido2.c
+++ b/source_code/main_mcu/src/LOGIC/logic_fido2.c
@@ -390,7 +390,7 @@ void logic_fido2_process_get_assertion(fido2_get_assertion_req_message_t* reques
     
     /* Ask for user permission, automatically pre increment signing counter upon success recall */
     fido2_return_code_te temp_return = FIDO2_SUCCESS;
-    temp_return = logic_user_get_webauthn_credential_key_for_rp(rp_id_copy, user_handle, &user_handle_len, credential_id, private_key, &temp_sign_count, request->allow_list.tag, request->allow_list.len);
+    temp_return = logic_user_get_webauthn_credential_key_for_rp(rp_id_copy, user_handle, &user_handle_len, credential_id, private_key, &temp_sign_count, request->allow_list.tag, request->allow_list.len, request->flags);
 
     /* Success? */
     if (temp_return == FIDO2_SUCCESS)

--- a/source_code/main_mcu/src/LOGIC/logic_user.h
+++ b/source_code/main_mcu/src/LOGIC/logic_user.h
@@ -33,7 +33,7 @@
 #define CHECK_PASSWORD_TIMER_VAL    4000
 
 /* Prototypes */
-fido2_return_code_te logic_user_get_webauthn_credential_key_for_rp(cust_char_t* rp_id, uint8_t* user_handle, uint8_t *user_handle_len, uint8_t* credential_id, uint8_t* private_key, uint32_t* count, uint8_t credential_id_allow_list[FIDO2_ALLOW_LIST_MAX_SIZE][FIDO2_CREDENTIAL_ID_LENGTH], uint16_t credential_id_allow_list_length);
+fido2_return_code_te logic_user_get_webauthn_credential_key_for_rp(cust_char_t* rp_id, uint8_t* user_handle, uint8_t *user_handle_len, uint8_t* credential_id, uint8_t* private_key, uint32_t* count, uint8_t credential_id_allow_list[FIDO2_ALLOW_LIST_MAX_SIZE][FIDO2_CREDENTIAL_ID_LENGTH], uint16_t credential_id_allow_list_length, uint8_t flags);
 RET_TYPE logic_user_ask_for_credentials_keyb_output(uint16_t parent_address, uint16_t child_address, BOOL skip_login_prompt_and_int_choice, BOOL* usb_selected, lock_feature_te keys_to_send_before_login, BOOL skip_login_prompt);
 fido2_return_code_te logic_user_store_webauthn_credential(cust_char_t* rp_id, uint8_t* user_handle, uint8_t user_handle_len, cust_char_t* user_name, cust_char_t* display_name, uint8_t* private_key, uint8_t* credential_id);
 ret_type_te logic_user_create_new_user_for_existing_card(cpz_lut_entry_t* cpz_entry, uint16_t sec_preferences, uint16_t language_id, uint16_t usb_layout_id, uint16_t ble_layout_id, uint8_t* new_user_id);


### PR DESCRIPTION
A platform might send a "silent" get assertion first to check if the
authenticator is the right one and has the credential. This assertion is
identified with up=0. If up is present and up=0 we will not prompt the
user.