### PR TITLE
Add option to enable showing of PIN on entry

### DIFF
--- a/source_code/main_mcu/src/FILESYSTEM/custom_fs_defines.h
+++ b/source_code/main_mcu/src/FILESYSTEM/custom_fs_defines.h
@@ -66,8 +66,9 @@
 #define SETTINGS_PIN_SHOWN_WHEN_BACK        14
 #define SETTINGS_UNLOCK_FEATURE_PARAM       15
 #define SETTINGS_DEVICE_TUTORIAL            16
+#define SETTING_SHOW_PIN_ON_ENTRY           17
 /* Set to define the number of settings used */
-#define SETTINGS_NB_USED                    17
+#define SETTINGS_NB_USED                    18
 
 /* Flags IDs */
 #define NB_DEVICE_FLAGS                     32

--- a/source_code/main_mcu/src/GUI/gui_prompts.c
+++ b/source_code/main_mcu/src/GUI/gui_prompts.c
@@ -576,6 +576,37 @@ void gui_prompts_display_3line_information_on_screen_and_wait(confirmationText_t
     }
 }
 
+/*! \fn     gui_prompts_get_char_to_display(uint8_t const * current_pin, uint8_t index)
+*   \brief  Get the next PIN value to display or '*' if PIN should be hidden
+*   \param  current_pin         Array containing the pin
+*   \param  index               Index into current_pin array
+*   \return Character to display
+*/
+static cust_char_t gui_prompts_get_char_to_display(uint8_t const * current_pin, uint8_t index)
+{
+    cust_char_t disp_char;
+    uint8_t curr_pin = current_pin[index];
+
+    if ((BOOL)custom_fs_settings_get_device_setting(SETTING_SHOW_PIN_ON_ENTRY) != FALSE)
+    {
+        if (curr_pin >= 0x0A)
+        {
+            disp_char = curr_pin + u'A' - 0x0A;
+        }
+        else
+        {
+            disp_char = curr_pin + u'0';
+        }
+    }
+    else
+    {
+        // Display '*'
+        disp_char = u'*';
+    }
+
+    return disp_char;
+}
+
 /*! \fn     gui_prompts_render_pin_enter_screen(uint8_t* current_pin, uint16_t selected_digit, uint16_t stringID, int16_t anim_direction, int16_t vert_anim_direction, int16_t hor_anim_direction, BOOL six_digit_prompt)
 *   \brief  Overwrite the digits on the current pin entering screen
 *   \param  current_pin         Array containing the pin
@@ -690,7 +721,8 @@ wheel_action_ret_te gui_prompts_render_pin_enter_screen(uint8_t* current_pin, ui
         {
             for (uint16_t i = 0; i < nb_of_digits; i++)
             {
-                sh1122_put_centered_char(&plat_oled_descriptor, PIN_PROMPT_DIGIT_X_OFFS + x_offset_for_digits + PIN_PROMPT_DIGIT_X_SPC*i + PIN_PROMPT_DIGIT_X_ADJ, PIN_PROMPT_UP_ARROW_Y+PIN_PROMPT_ARROW_HEIGHT+PIN_PROMPT_DIGIT_Y_SPACING+PIN_PROMPT_ASTX_Y_INC, u'*', TRUE);
+                cust_char_t disp_char = gui_prompts_get_char_to_display(current_pin, i);
+                sh1122_put_centered_char(&plat_oled_descriptor, PIN_PROMPT_DIGIT_X_OFFS + x_offset_for_digits + PIN_PROMPT_DIGIT_X_SPC*i + PIN_PROMPT_DIGIT_X_ADJ, PIN_PROMPT_UP_ARROW_Y+PIN_PROMPT_ARROW_HEIGHT+PIN_PROMPT_DIGIT_Y_SPACING+PIN_PROMPT_ASTX_Y_INC, disp_char, TRUE);
             }
         } 
         else
@@ -743,8 +775,8 @@ wheel_action_ret_te gui_prompts_render_pin_enter_screen(uint8_t* current_pin, ui
             {
                 if (six_digit_prompt == FALSE)
                 {
-                    /* Display '*' */
-                    sh1122_put_centered_char(&plat_oled_descriptor, PIN_PROMPT_DIGIT_X_OFFS + x_offset_for_digits + PIN_PROMPT_DIGIT_X_SPC*i + PIN_PROMPT_DIGIT_X_ADJ, PIN_PROMPT_UP_ARROW_Y+PIN_PROMPT_ARROW_HEIGHT+PIN_PROMPT_DIGIT_Y_SPACING+PIN_PROMPT_ASTX_Y_INC, u'*', TRUE);
+                    cust_char_t disp_char = gui_prompts_get_char_to_display(current_pin, i);
+                    sh1122_put_centered_char(&plat_oled_descriptor, PIN_PROMPT_DIGIT_X_OFFS + x_offset_for_digits + PIN_PROMPT_DIGIT_X_SPC*i + PIN_PROMPT_DIGIT_X_ADJ, PIN_PROMPT_UP_ARROW_Y+PIN_PROMPT_ARROW_HEIGHT+PIN_PROMPT_DIGIT_Y_SPACING+PIN_PROMPT_ASTX_Y_INC, disp_char, TRUE);
                 } 
                 else
                 {

--- a/source_code/main_mcu/src/GUI/gui_prompts.c
+++ b/source_code/main_mcu/src/GUI/gui_prompts.c
@@ -577,7 +577,8 @@ void gui_prompts_display_3line_information_on_screen_and_wait(confirmationText_t
 }
 
 /*! \fn     gui_prompts_get_char_to_display(uint8_t const * current_pin, uint8_t index)
-*   \brief  Get the next PIN value to display or '*' if PIN should be hidden
+*   \brief  Get the next PIN value to display or '*' if PIN should be hidden.
+*           Called whenever a non selected PIN digit needs to be displayed.
 *   \param  current_pin         Array containing the pin
 *   \param  index               Index into current_pin array
 *   \return Character to display
@@ -585,17 +586,16 @@ void gui_prompts_display_3line_information_on_screen_and_wait(confirmationText_t
 static cust_char_t gui_prompts_get_char_to_display(uint8_t const * current_pin, uint8_t index)
 {
     cust_char_t disp_char;
-    uint8_t curr_pin = current_pin[index];
 
     if ((BOOL)custom_fs_settings_get_device_setting(SETTING_SHOW_PIN_ON_ENTRY) != FALSE)
     {
-        if (curr_pin >= 0x0A)
+        if (current_pin[index] >= 0x0A)
         {
-            disp_char = curr_pin + u'A' - 0x0A;
+            disp_char = current_pin[index] + u'A' - 0x0A;
         }
         else
         {
-            disp_char = curr_pin + u'0';
+            disp_char = current_pin[index] + u'0';
         }
     }
     else


### PR DESCRIPTION
Add a setting item to allow user to turn on showing PIN when entering.
Default is OFF (hide PIN on entry).