### PR TITLE
fix main_mcu firmware makefile and add management for V2 dev config

### DIFF
--- a/source_code/main_mcu/Makefile
+++ b/source_code/main_mcu/Makefile
@@ -74,7 +74,8 @@ INC_DIRS := \
 -I"src/RNG" \
 -I"src/BearSSL/src" \
 -I"src/BearSSL/inc" \
--I"src/CRYPTO"
+-I"src/CRYPTO" \
+-I"src/I2C"
 
 LIB_DIRS := \
 -L"src/ASF/thirdparty/CMSIS/Lib/GCC" \
@@ -88,7 +89,6 @@ INC_DIRS +=
 endif
 
 C_SRCS +=  \
-src/ACCELEROMETER/lis2hh12.c \
 src/BearSSL/src/symcipher/aes_ct.c \
 src/BearSSL/src/symcipher/aes_ct_ctr.c \
 src/BearSSL/src/symcipher/aes_ct_ctrcbc.c \
@@ -126,7 +126,8 @@ src/CLOCKS/driver_clocks.c \
 src/COMMS/comms_aux_mcu.c \
 src/COMMS/comms_hid_msgs.c \
 src/COMMS/comms_hid_msgs_debug.c \
-src/debug.c \
+src/debug_minible.c \
+src/debug_minible_v2.c \
 src/DMA/dma.c \
 src/FILESYSTEM/custom_bitstream.c \
 src/FILESYSTEM/custom_fs.c \
@@ -152,7 +153,6 @@ src/LOGIC/logic_user.c \
 src/LOGIC/logic_accelerometer.c \
 src/NODEMGMT/nodemgmt.c \
 src/OLED/mooltipass_graphics_bundle.c \
-src/OLED/sh1122.c \
 src/PLATFORM/platform_io.c \
 src/RNG/rng.c \
 src/SECURITY/fuses.c \
@@ -174,15 +174,29 @@ src/ASF/sam0/utils/syscalls/gcc/syscalls.c \
 src/main.c \
 src/LOGIC/logic_fido2.c \
 src/CRYPTO/monocypher.c \
-src/CRYPTO/monocypher-ed25519.c
+src/CRYPTO/monocypher-ed25519.c \
+src/I2C/driver_i2c.c \
+src/I2C/mp2710.c \
+src/I2C/pcf85263a.c
+
 
 ifeq ($(PLATFORM),)
 	PLATFORM = PLAT_V7_SETUP
+	C_SRCS +=\
+	src/ACCELEROMETER/lis2hh12.c \
+	src/OLED/sh1122.c
+else ifeq ($(PLATFORM), V2_PLAT_V1_SETUP)
+	C_SRCS +=\
+		src/ACCELEROMETER/lis2dh12.c \
+		src/OLED/ssd1363.c
 endif
 
 TEXT_SEC_START = 0x2000
 ifeq ($(PLATFORM),PLAT_V7_SETUP)
 	TEXT_SEC_START = 0x8000
+else ifeq ($(PLATFORM), V2_PLAT_V1_SETUP)
+	# remove bootloader while dev this
+	TEXT_SEC_START = 0x0
 endif
 
 C_FLAGS := -mthumb
@@ -200,7 +214,7 @@ C_FLAGS += -fdata-sections -ffunction-sections -mlong-calls -Wall -mcpu=cortex-m
 C_DEFINES := -D__SAMD21G18A__ -DBOARD=USER_BOARD -DARM_MATH_CM0PLUS=true -D__CORTEX_SC=0 -DBR_ARMEL_CORTEXM_GCC=1 -DBR_amd64=0 -DBR_BE_UNALIGNED=0 -DBR_CT_MUL15=0 -DBR_ENABLE_INTRINSICS=0 -DBR_CT_MUL31=0 -DBR_i386=0 -DBR_LE_UNALIGNED=0 -DBR_NO_ARITH_SHIFT=0 -DBR_POWER_ASM_MACROS=0 -D_ARCH_PWR8=0 -D_MSC_VER=0 -D_M_IX86=0 -D_M_X64=0 -D__clang__=0 -DBR_POWER8=0
 
 LINKER_SCRIPT_DEP +=  \
-src/ASF/sam0/utils/linker_scripts/samd21/gcc/samd21g18a_flash.ld
+src/ASF/sam0/utils/linker_scripts/samd21/gcc/samd21g18a_flash.ld 
 
 OBJS := $(C_SRCS:.c=.o)
 OBJS :=  $(addprefix $(OUTPUT_DIR)/,$(OBJS))

--- a/source_code/main_mcu/Makefile
+++ b/source_code/main_mcu/Makefile
@@ -214,7 +214,7 @@ C_FLAGS += -fdata-sections -ffunction-sections -mlong-calls -Wall -mcpu=cortex-m
 C_DEFINES := -D__SAMD21G18A__ -DBOARD=USER_BOARD -DARM_MATH_CM0PLUS=true -D__CORTEX_SC=0 -DBR_ARMEL_CORTEXM_GCC=1 -DBR_amd64=0 -DBR_BE_UNALIGNED=0 -DBR_CT_MUL15=0 -DBR_ENABLE_INTRINSICS=0 -DBR_CT_MUL31=0 -DBR_i386=0 -DBR_LE_UNALIGNED=0 -DBR_NO_ARITH_SHIFT=0 -DBR_POWER_ASM_MACROS=0 -D_ARCH_PWR8=0 -D_MSC_VER=0 -D_M_IX86=0 -D_M_X64=0 -D__clang__=0 -DBR_POWER8=0
 
 LINKER_SCRIPT_DEP +=  \
-src/ASF/sam0/utils/linker_scripts/samd21/gcc/samd21g18a_flash.ld 
+src/ASF/sam0/utils/linker_scripts/samd21/gcc/samd21g18a_flash.ld
 
 OBJS := $(C_SRCS:.c=.o)
 OBJS :=  $(addprefix $(OUTPUT_DIR)/,$(OBJS))

--- a/source_code/main_mcu/src/I2C/driver_i2c.c
+++ b/source_code/main_mcu/src/I2C/driver_i2c.c
@@ -263,7 +263,7 @@ void sercom_i2c_read_array_from_device(Sercom* sercom_pt, uint8_t addr_7b, uint8
     /* Check for bus errors */
     if (sercom_i2c_check_for_errors(sercom_pt) != RETURN_OK)
     {
-        return 0x00;
+        return;
     }
 
     sercom_pt->I2CM.ADDR.reg = (addr_7b << 1) | 0;  // Put address on bus
@@ -273,7 +273,7 @@ void sercom_i2c_read_array_from_device(Sercom* sercom_pt, uint8_t addr_7b, uint8
     /* Check for bus errors */
     if (sercom_i2c_check_for_errors(sercom_pt) != RETURN_OK)
     {
-        return 0x00;
+        return;
     }
 
     sercom_pt->I2CM.DATA.reg = reg_addr;            // Send register address
@@ -283,7 +283,7 @@ void sercom_i2c_read_array_from_device(Sercom* sercom_pt, uint8_t addr_7b, uint8
     /* Check for bus errors */
     if (sercom_i2c_check_for_errors(sercom_pt) != RETURN_OK)
     {
-        return 0x00;
+        return;
     }
 
     /* Issue restart condition, put address on bus with read */
@@ -297,7 +297,7 @@ void sercom_i2c_read_array_from_device(Sercom* sercom_pt, uint8_t addr_7b, uint8
         {
             if (timer_has_timer_expired(TIMER_I2C_TIMEOUT, TRUE) == TIMER_EXPIRED)
             {
-                return RETURN_NOK;
+                return;
             }
         }
 


### PR DESCRIPTION
# Compile error

Actual makefile compilation doesn't work due to missing *debug.c* file. I suppose it's was replaced by *debug_minible.c* and *debug_minible_v2.c*. So I replaced it by this two files.

# minible V2 config

I added some *V2_PLAT_V1_SETUP* specific setup to be able to compile main MCU for V2 Debug board.

PS: I've update main MCU firmware makefile by trying to match the *mini_ble.cproj* config but I could missed some changes.
